### PR TITLE
Register :msgpack as a renderable content type

### DIFF
--- a/lib/msgpack_rails.rb
+++ b/lib/msgpack_rails.rb
@@ -25,6 +25,19 @@ if defined?(::Rails)
     class Rails < ::Rails::Engine
       initializer "msgpack_rails" do
         ::ActiveRecord::Base.send(:include, ActiveModel::Serializers::MessagePack)
+
+        # Add a msgpack MIME type
+        Mime::Type.register "application/msgpack", :msgpack
+
+        # Register :msgpack as a renderer.
+        # Note that the options are currently only passed to the `as_json`
+        # call. This may not be the desired behaviour.
+        ActionController::Renderers.add :msgpack do |data, options|
+          data = data.as_json(options)
+
+          self.content_type ||= Mime::MSGPACK
+          self.response_body = data.to_msgpack()
+        end
       end
     end
   end


### PR DESCRIPTION
Enable a Rails server to respond to 'application/msgpack' requests with
a renderer that calls `to_msgpack`.

This commit has no tests and may not handle render options in an optimal
way, so it may be desirable to view it as a working proof-of-concept. It
does appear to work, though.
