### PR TITLE
Fix msgpack renderer for Rails 4.

### DIFF
--- a/lib/msgpack_rails.rb
+++ b/lib/msgpack_rails.rb
@@ -33,7 +33,7 @@ if defined?(::Rails)
           end
         end
 
-        ::Mime::Type.register "application/msgpack", :msgpack
+        ::Mime::Type.register "application/msgpack", :msgpack unless defined? Mime::MSGPACK
 
         ::ActionController::Renderers.add :msgpack do |data, options|
           self.content_type = Mime::MSGPACK

--- a/lib/msgpack_rails.rb
+++ b/lib/msgpack_rails.rb
@@ -36,8 +36,8 @@ if defined?(::Rails)
         ::Mime::Type.register "application/msgpack", :msgpack unless defined? Mime::MSGPACK
 
         ::ActionController::Renderers.add :msgpack do |data, options|
-          self.content_type = Mime::MSGPACK
-          self.response_body = data.as_msgpack(options)
+          self.content_type ||= Mime::MSGPACK
+          data.to_msgpack(options) unless data.kind_of?(String)
         end
       end
     end


### PR DESCRIPTION
I had trouble using `render msgpack: object` in Rails 4.2. This change fixed it for me. I can't vouch for its backwards compatibility.
